### PR TITLE
Windows name fix shouldn't just affect directories

### DIFF
--- a/src/precompile.js
+++ b/src/precompile.js
@@ -88,8 +88,6 @@ function precompile(input, opts) {
         for(var i=0; i<templates.length; i++) {
             var name = templates[i].replace(path.join(input, '/'), '');
 
-            name = name.replace(/\\/g, '/');
-
             try {
                 precompiled.push( _precompile(
                     fs.readFileSync(templates[i], 'utf-8'),
@@ -108,6 +106,9 @@ function precompile(input, opts) {
             }
         }
     }
+    
+    var last = precompiled[precompiled.length - 1];
+    last.name = last.name.replace(/\\/g, '/');
 
     return wrapper(precompiled, opts);
 }

--- a/src/precompile.js
+++ b/src/precompile.js
@@ -106,9 +106,6 @@ function precompile(input, opts) {
             }
         }
     }
-    
-    var last = precompiled[precompiled.length - 1];
-    last.name = last.name.replace(/\\/g, '/');
 
     return wrapper(precompiled, opts);
 }
@@ -119,6 +116,8 @@ function _precompile(str, name, env) {
     var asyncFilters = env.asyncFilters;
     var extensions = env.extensionsList;
     var template;
+
+    name = name.replace(/\\/g, '/');
 
     try {
         template = compiler.compile(str,

--- a/tests/precompile.js
+++ b/tests/precompile.js
@@ -31,6 +31,20 @@
 
                 expect(fileName).to.not.contain('\\');
             });
+
+            it('should return *NIX path seperators, when name is passed as option', function() {
+                var fileName;
+
+                precompile('<span>test</span>', {
+                    name: 'path\\to\\file.j2',
+                    isString: true,
+                    wrapper: function(templates) {
+                        fileName = templates[0].name;
+                    }
+                });
+
+                expect(fileName).to.not.contain('\\');
+            });
         });
     });
 })();


### PR DESCRIPTION
I initially created https://github.com/mozilla/nunjucks/pull/761 to deal with incorrectly formatted paths, when precompiling in Windows. The original pull request only dealt with directories, this change also deals with file names.
